### PR TITLE
CMakeLists: check if libatomic is needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,7 @@ include(CheckCXXSourceCompiles)
 check_cxx_source_compiles("
     #include <atomic>
     int main() {
-        std::atomic<uint64_t> w;
+        std::atomic<uint64_t> w{0};
         return ++w;
     }
 " CJSH_BUILDS_WITHOUT_LIBATOMIC)


### PR DESCRIPTION
@CadenFinley Works on ppc, I can drop a manual passing of `-latomic` flag now. Borrowed from https://github.com/uxlfoundation/oneTBB/pull/987/files#r1212790095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a compile-time check for atomic library support and conditional linking of the atomic library when available.
  * Enables builds to succeed across a wider range of system configurations and toolchains without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->